### PR TITLE
fix the profile/settings/archive/etc page width

### DIFF
--- a/whatsweb/app/ubuntutheme.js
+++ b/whatsweb/app/ubuntutheme.js
@@ -62,6 +62,7 @@ window.addEventListener("click", function() {
 
 function main(){
       document.getElementById("app").getElementsByClassName('two')[0].childNodes[3].style.display = 'none';
+      document.getElementById("app").getElementsByClassName('two')[0].childNodes[1].childNodes[1].style.display = 'none';
       document.getElementById('app').getElementsByClassName('two')[0].style.minWidth = 'auto';
       document.getElementById('app').getElementsByClassName('two')[0].style.minHeight = 'auto';
 


### PR DESCRIPTION
The size of profile/settings/new chat/new group/etc page always bothered me; this should fix it so it take the full width just like the chat list.

p.s.
not to be confused with the group/contact info page to get that to take the full width `document.getElementById("app").getElementsByClassName('two')[0].childNodes[1].childNodes[0]` would need to be hidden. but this should only be done when inside a chat/group; as that's the element this pr fix the width for