### PR TITLE
Add notifications when receiving a new message.

### DIFF
--- a/whatsweb/CMakeLists.txt
+++ b/whatsweb/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+project(whatsweb C CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+#Notification module
+add_subdirectory(qml-notify-module)
+
+# Install QML APP
+install(DIRECTORY app/ DESTINATION ${CMAKE_INSTALL_PREFIX}/app/)
+
+# Install main project files
+install(FILES whatsweb.apparmor DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES whatsweb.desktop DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES manifest.json DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+#Icon
+install(FILES icon.png DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+#SPECIFIC FILES FOR NOTIFICATIONS
+install(PROGRAMS pushexec DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES whatsweb-push-helper.json DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES whatsweb-push.apparmor DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES push-apparmor.json DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+#OTHER FILES
+install(FILES content-hub.json DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES icon-splash.png DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/whatsweb/app/ubuntutheme.js
+++ b/whatsweb/app/ubuntutheme.js
@@ -12,6 +12,9 @@ updatenotificacion = 0;
 allownotification = 0;
 
 
+//Request by default webnofications permission
+Notification.requestPermission();
+
 // Listeners to startup APP
 window.addEventListener("load", function(event) {
     console.log("Loaded");
@@ -116,7 +119,8 @@ function main(){
     }
   });
   disablenotifications();
-  
+  //Request by default webnofications permission
+  Notification.requestPermission();
 }
 
 
@@ -178,18 +182,19 @@ function showchatlist(){
 }
 
 function disablenotifications(){
-  // Disable update available notification
-  if (document.querySelector('span[data-icon="alert-update"]')) {
-    document.querySelector('span[data-icon="alert-update"]').parentElement.parentElement.style.display = 'none';
-    console.log("Disabled update available notification");
-    updatenotification = 1;
-  }
-  // Disable request to allow notifications
-  if (document.querySelector('span[data-icon="alert-notification"]')) {
-    document.querySelector('span[data-icon="alert-notification"]').parentElement.parentElement.style.display = 'none'; 
-    console.log("Disabled request allow notification");
-    allownotification = 1;
-  }
+  //Now we need notifications to show
+  // // Disable update available notification
+  // if (document.querySelector('span[data-icon="alert-update"]')) {
+  //   document.querySelector('span[data-icon="alert-update"]').parentElement.parentElement.style.display = 'none';
+  //   console.log("Disabled update available notification");
+  //   updatenotification = 1;
+  // }
+  // // Disable request to allow notifications
+  // if (document.querySelector('span[data-icon="alert-notification"]')) {
+  //   document.querySelector('span[data-icon="alert-notification"]').parentElement.parentElement.style.display = 'none'; 
+  //   console.log("Disabled request allow notification");
+  //   allownotification = 1;
+  // }
 }
 
 function modaldialogresponsive(){
@@ -254,3 +259,133 @@ function clean() {
       console.log('Service Worker registration failed: ', err);
   });
 }
+
+
+
+//Injection AUdio testid
+
+(function() {
+  if (window.__my_audio_hook_installed) return;
+  window.__my_audio_hook_installed = true;
+
+  function logAudioEvent(info) {
+    try {
+      console.log("[DbgAud] " + info);
+    } catch (e) { /* safe */ }
+  }
+
+  // 1) Intercepter constructeur Audio (alias de HTMLAudioElement)
+  try {
+    const OrigAudio = window.Audio;
+    window.Audio = function(src) {
+      const a = new OrigAudio(src);
+      // try {
+      //   // log creation + src
+      //  // logAudioEvent("Audio constructed src=" + (src || ""));
+      // } catch(e){}
+      // attach listeners to catch play
+      a.addEventListener('play', function(){ logAudioEvent((a.currentSrc || a.src || "")); }, {passive:true});
+      a.addEventListener('playing', function(){ logAudioEvent((a.currentSrc || a.src || "")); }, {passive:true});
+      return a;
+    };
+    // preserve prototype / static props
+    window.Audio.prototype = OrigAudio.prototype;
+    Object.getOwnPropertyNames(OrigAudio).forEach(function(k){
+      try { if (!(k in window.Audio)) window.Audio[k] = OrigAudio[k]; } catch(e){}
+    });
+  } catch(e) {}
+
+  // 2) Intercepter HTMLAudioElement / HTMLMediaElement.play
+  try {
+    const mp = HTMLMediaElement && HTMLMediaElement.prototype;
+    if (mp && !mp.__play_hooked__) {
+      const origPlay = mp.play;
+      mp.__play_hooked__ = true;
+      mp.play = function() {
+        try {
+          const src = this.currentSrc || this.src || "";
+          logAudioEvent( src);
+        } catch(e){}
+        return origPlay.apply(this, arguments);
+      };
+      // also listen to src changes (attribute)
+      const origSetAttribute = Element.prototype.setAttribute;
+      Element.prototype.setAttribute = function(name, value) {
+        try {
+          if ((this.tagName || "").toLowerCase() === "audio" && name === "src") {
+            logAudioEvent(value);
+          }
+        } catch(e){}
+        return origSetAttribute.apply(this, arguments);
+      };
+      // intercept setting .src
+      try {
+        const desc = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'src');
+        if (desc && desc.set && !desc.set.__hooked__) {
+          const origSetter = desc.set;
+          desc.set = function(v) {
+            try { logAudioEvent(v); } catch(e){}
+            return origSetter.call(this, v);
+          };
+          Object.defineProperty(HTMLMediaElement.prototype, 'src', desc);
+          desc.set.__hooked__ = true;
+        }
+      } catch(e){}
+    }
+  } catch(e){}
+
+  // 3) Intercepter WebAudio: AudioContext.prototype.createBufferSource + start()
+  try {
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if (AC) {
+      const origCreate = AC.prototype.createBufferSource;
+      AC.prototype.createBufferSource = function() {
+        const srcNode = origCreate.apply(this, arguments);
+        try {
+          const origStart = srcNode.start;
+          srcNode.start = function(/*when, offset, duration*/) {
+            try {
+              // attempt to describe the buffer (duration) or associated info
+              const dur = srcNode.buffer ? srcNode.buffer.duration : "unknown";
+              logAudioEvent("WebAudio start bufferDuration=" + dur);
+            } catch(e){}
+            return origStart.apply(this, arguments);
+          };
+        } catch(e){}
+        return srcNode;
+      };
+    }
+  } catch(e){}
+
+  // 4) MutationObserver to catch dynamically added <audio> elements
+  try {
+    const mo = new MutationObserver(function(mutations) {
+      for (const m of mutations) {
+        for (const n of m.addedNodes || []) {
+          try {
+            if (n && n.tagName && n.tagName.toLowerCase() === 'audio') {
+              const a = n;
+              logAudioEvent( (a.currentSrc || a.src || ""));
+              a.addEventListener('play', function(){ logAudioEvent((a.currentSrc||a.src||"")); }, {passive:true});
+            }
+          } catch(e){}
+        }
+      }
+    });
+    mo.observe(document, { childList: true, subtree: true });
+  } catch(e){}
+
+  // 5) Optional: intercept creation via createElement
+  try {
+    const origCreate = Document.prototype.createElement;
+    Document.prototype.createElement = function(tagName) {
+      const node = origCreate.apply(this, arguments);
+      try {
+        if ((tagName||"").toLowerCase() === 'audio') {
+          node.addEventListener('play', function(){ logAudioEvent(  (node.currentSrc||node.src||"")); }, {passive:true});
+        }
+      } catch(e){}
+      return node;
+    };
+  } catch(e){}
+})();

--- a/whatsweb/clickable.yaml
+++ b/whatsweb/clickable.yaml
@@ -1,0 +1,3 @@
+clickable_minimum_required: 8.0.0
+builder: cmake
+kill: qmlscene

--- a/whatsweb/manifest.json
+++ b/whatsweb/manifest.json
@@ -11,7 +11,7 @@
             "content-hub": "content-hub.json"
         }
     },
-    "version": "0.2.8",
+    "version": "0.3.0",
     "maintainer": "Adrian Campos <adriancampos@teachelp.com>",
-    "framework" : "ubuntu-sdk-16.04.5"
+    "framework" : "ubuntu-sdk-20.04"
 }

--- a/whatsweb/manifest.json
+++ b/whatsweb/manifest.json
@@ -1,17 +1,20 @@
 {
-    "name": "alefnode.whatsweb",
-    "description": "WhatsApp client with Responsive Design.",
-    "architecture": "@CLICK_ARCH@",
-
-    "title": "whatsweb",
-    "hooks": {
-        "whatsweb": {
-            "apparmor": "whatsweb.apparmor",
-            "desktop":  "whatsweb.desktop",
-            "content-hub": "content-hub.json"
-        }
+  "name": "alefnode.whatsweb",
+  "description": "WhatsApp client with Responsive Design.",
+  "architecture": "@CLICK_ARCH@",
+  "title": "whatsweb",
+  "hooks": {
+    "whatsweb": {
+      "apparmor": "whatsweb.apparmor",
+      "desktop": "whatsweb.desktop",
+      "content-hub": "content-hub.json"
     },
-    "version": "0.3.0",
-    "maintainer": "Adrian Campos <adriancampos@teachelp.com>",
-    "framework" : "ubuntu-sdk-20.04"
+    "push": {
+      "apparmor": "whatsweb-push.apparmor",
+      "push-helper": "whatsweb-push-helper.json"
+    }
+  },
+  "version": "0.3.0",
+  "maintainer": "Adrian Campos <adriancampos@teachelp.com>",
+  "framework": "ubuntu-sdk-20.04"
 }

--- a/whatsweb/push-apparmor.json
+++ b/whatsweb/push-apparmor.json
@@ -1,0 +1,8 @@
+{
+    "template": "ubuntu-push-helper",
+    "policy_groups": [
+        "push-notification-client"
+    ],
+    "policy_version": 20.04
+}
+ 

--- a/whatsweb/pushexec
+++ b/whatsweb/pushexec
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+
+import sys
+
+f1, f2 = sys.argv[1:3]
+
+open(f2, "w").write(open(f1).read()) 

--- a/whatsweb/qml-notify-module/CMakeLists.txt
+++ b/whatsweb/qml-notify-module/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(NotificationsPlugin LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Qt5
+find_package(Qt5 REQUIRED COMPONENTS Core Qml Quick DBus)
+
+# GLib + libnotify via pkg-config
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GLIB REQUIRED glib-2.0)
+pkg_check_modules(LIBNOTIFY REQUIRED libnotify)
+
+add_library(NotificationsPlugin SHARED
+    NotificationHelper.cpp
+    NotificationHelper.h  
+    plugin.cpp
+)
+
+# Inclure les headers de GLib/libnotify
+target_include_directories(NotificationsPlugin
+    PRIVATE
+        ${GLIB_INCLUDE_DIRS}
+        ${LIBNOTIFY_INCLUDE_DIRS}
+)
+
+# Définir les flags de compilation si pkg-config en fournit
+target_compile_options(NotificationsPlugin PRIVATE
+    ${GLIB_CFLAGS_OTHER}
+    ${LIBNOTIFY_CFLAGS_OTHER}
+)
+
+# Lier Qt + DBus + Glib + libnotify
+target_link_libraries(NotificationsPlugin
+    PRIVATE
+        Qt5::Core
+        Qt5::Qml
+        Qt5::Quick
+        Qt5::DBus
+        ${GLIB_LIBRARIES}
+        ${LIBNOTIFY_LIBRARIES}
+)
+
+# Installation dans le chemin QML
+install(TARGETS NotificationsPlugin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/qml-plugins/Pparent/Notifications)
+
+install(FILES qmldir
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/qml-plugins/Pparent/Notifications)

--- a/whatsweb/qml-notify-module/NotificationHelper.cpp
+++ b/whatsweb/qml-notify-module/NotificationHelper.cpp
@@ -1,0 +1,135 @@
+#include "NotificationHelper.h"
+#include <QDebug>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QPointer>
+#include <QByteArray>
+#include <QDBusMessage>
+#include <QJsonDocument>
+#include <QDebug>
+#include <QJsonArray>
+
+#define PUSH_SERVICE "com.lomiri.PushNotifications"
+#define POSTAL_SERVICE "com.lomiri.Postal"
+#define PUSH_PATH "/com/lomiri/PushNotifications"
+#define POSTAL_PATH "/com/lomiri/Postal"
+#define PUSH_IFACE "com.lomiri.PushNotifications"
+#define POSTAL_IFACE "com.lomiri.Postal"
+
+
+
+QJsonObject NotificationHelper::buildSummaryMessage(const QString &title,const QString &message) {
+
+
+    QString appid=push_app_id.section('_', 0, 0);
+    QString activityid=push_app_id.section('_', 1, 1);    
+    QString icon = QString("/opt/click.ubuntu.com/")+appid+QString("/current/icon.png");
+
+    QJsonObject c;
+    c["summary"] = title;
+    if (message.length()>0)
+        c["body"] = message;
+    c["popup"] = true;
+    c["persist"] = true;
+    c["icon"] = icon;
+    QJsonArray actions = QJsonArray();
+    QString actionUri = QStringLiteral("appid://")+appid+"/"+activityid+"/current-user-version";
+    actions.append(actionUri);
+    c["actions"] = actions;
+
+    QJsonObject notification;
+    notification["card"] = c;
+    notification["sound"] = true;
+    notification["vibrate"] = true;
+    QJsonObject res;
+    res["notification"] = notification;
+    return res;
+}
+
+
+//shamelessly stolen from accounts-polld
+bool NotificationHelper::sendJSON(const QJsonObject &message)
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(POSTAL_SERVICE,
+                                                      makePath(push_app_id),
+                                                      POSTAL_IFACE,
+                                                      "Post");
+    msg << push_app_id;
+    QByteArray data = QJsonDocument(message).toJson(QJsonDocument::Compact);
+    msg << QString::fromUtf8(data);
+
+    qDebug() << "[POST] >>  " << msg;
+
+    QDBusMessage reply = m_conn.call(msg);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qDebug() << "[POST ERROR] " << reply.errorMessage();
+        return false;
+    }
+    qDebug() << "[POST SUCCESS] >> Message posted.";
+    QJsonObject n = message.value("notification").toObject();
+    QString tag = n.value("tag").toString();
+    return true;
+}
+
+
+
+bool NotificationHelper::updateCount(const int count)
+{
+    bool visible = count != 0;
+    QDBusMessage message = QDBusMessage::createMethodCall(POSTAL_SERVICE,
+                                                          makePath(push_app_id),
+                                                          POSTAL_IFACE,
+                                                          "SetCounter");
+    message << push_app_id << count << visible;
+    bool result = m_conn.send(message);
+    if (result) {
+        qDebug() << "[COUNT] >> Updated.";
+    }
+    return result;
+    
+}
+
+//shamelessly stolen from accounts-polld
+QByteArray NotificationHelper::makePath(const QString &appId)
+{
+    QByteArray path(QByteArrayLiteral("/com/lomiri/Postal/"));
+
+    QByteArray pkg = appId.split('_').first().toUtf8();
+    for (int i = 0; i < pkg.count(); i++) {
+        char buffer[10];
+        char c = pkg[i];
+        switch (c) {
+        case '+':
+        case '.':
+        case '-':
+        case ':':
+        case '~':
+        case '_':
+            sprintf(buffer, "_%.2x", c);
+            path += buffer;
+            break;
+        default:
+            path += c;
+        }
+    }
+    qDebug() << "[PATH] >> " << path;
+    return path;
+}
+
+NotificationHelper::NotificationHelper(QObject *parent) : QObject(parent),
+    m_conn(QDBusConnection::sessionBus())
+{
+
+}
+
+
+void NotificationHelper::showNotificationMessage(const QString &title,const QString &message)
+{
+    sendJSON(buildSummaryMessage(title,message));
+}
+
+QString NotificationHelper::get_push_app_id() 
+{ return push_app_id; }
+   
+void NotificationHelper::set_push_app_id(QString value)
+{ push_app_id = value; }

--- a/whatsweb/qml-notify-module/NotificationHelper.h
+++ b/whatsweb/qml-notify-module/NotificationHelper.h
@@ -1,0 +1,39 @@
+#ifndef NOTIFICATIONHELPER_H
+#define NOTIFICATIONHELPER_H
+
+#include <QObject>
+#include <QString>
+#include <QDBusConnection>
+#include <QJsonObject>
+
+class NotificationHelper : public QObject
+{
+Q_PROPERTY(QString push_app_id READ get_push_app_id WRITE set_push_app_id)
+Q_OBJECT
+public:
+    
+    explicit NotificationHelper(QObject *parent = 0);
+
+    //Send a notification from title and message information
+    Q_INVOKABLE void showNotificationMessage(const QString &title,const QString &message);
+    
+    //Update notification counter on icon
+    Q_INVOKABLE bool updateCount(const int count);
+    
+    // Send a notification based on JSON notification
+    bool sendJSON(const QJsonObject &message);
+    
+    QString get_push_app_id();
+    void set_push_app_id(QString value);
+
+private:
+    QJsonObject buildSummaryMessage(const QString &title,const QString &message);
+    QByteArray makePath(const QString &appId);
+
+    QDBusConnection m_conn;
+    QStringList m_tags;
+    QString push_app_id;
+};
+
+#endif // NOTIFICATIONHELPER_H
+ 

--- a/whatsweb/qml-notify-module/plugin.cpp
+++ b/whatsweb/qml-notify-module/plugin.cpp
@@ -1,0 +1,19 @@
+#include <qqml.h>
+#include <QQmlExtensionPlugin>
+#include "NotificationHelper.h"
+
+class NotificationsPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QQmlExtensionInterface")
+
+public:
+    void registerTypes(const char *uri) override
+    {
+        // Doit correspondre au module indiqué dans qmldir
+        Q_ASSERT(uri == QStringLiteral("Pparent.Notifications"));
+        qmlRegisterType<NotificationHelper>(uri, 1, 0, "NotificationHelper");
+    }
+};
+
+#include "plugin.moc"

--- a/whatsweb/qml-notify-module/qmldir
+++ b/whatsweb/qml-notify-module/qmldir
@@ -1,0 +1,2 @@
+module Pparent.Notifications
+plugin NotificationsPlugin 

--- a/whatsweb/whatsweb-push-helper.json
+++ b/whatsweb/whatsweb-push-helper.json
@@ -1,0 +1,3 @@
+{
+    "exec": "pushexec"
+} 

--- a/whatsweb/whatsweb-push.apparmor
+++ b/whatsweb/whatsweb-push.apparmor
@@ -1,0 +1,7 @@
+{
+    "template": "ubuntu-push-helper",
+    "policy_groups": [
+        "push-notification-client"
+    ],
+    "policy_version": 20.04
+} 

--- a/whatsweb/whatsweb.apparmor
+++ b/whatsweb/whatsweb.apparmor
@@ -8,5 +8,5 @@
          "content_exchange_source",
          "keep-display-on"
     ],
-    "policy_version": 16.04
+    "policy_version": 20.04
 }

--- a/whatsweb/whatsweb.apparmor
+++ b/whatsweb/whatsweb.apparmor
@@ -1,12 +1,13 @@
 {
-    "policy_groups": [
-         "webview",
-         "networking",
-         "audio",
-         "video",
-         "content_exchange",
-         "content_exchange_source",
-         "keep-display-on"
-    ],
-    "policy_version": 20.04
+  "policy_groups": [
+    "webview",
+    "networking",
+    "audio",
+    "video",
+    "content_exchange",
+    "content_exchange_source",
+    "keep-display-on",
+    "push-notification-client"
+  ],
+  "policy_version": 20.04
 }

--- a/whatsweb/whatsweb.desktop
+++ b/whatsweb/whatsweb.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=WhatsWeb
 Comment=Whatsapp with Responsive
-Exec=qmlscene %u app/Main.qml  --scaling --multisample --gles --disable-gpu
+Exec=qmlscene %u -I qml-plugins/ app/Main.qml  --scaling --multisample --gles --disable-gpu
 Terminal=false
 Type=Application
 Icon=icon.png


### PR DESCRIPTION
This push request allows to send a desktop notification when a new message is received and the app is opened in background, with suspend disabled (from ubuntu tweaks).

It detects new messages based on 3 signals: desktop web notification, page title change, and notification audio playback.

I requires to compile a qml module in c++, and to set the app unconfined.