### PR TITLE
Fix Search messages in chat window + adpat fontsize to changes upstream

### DIFF
--- a/whatsweb/app/Main.qml
+++ b/whatsweb/app/Main.qml
@@ -29,8 +29,8 @@ MainView {
 
         property int webviewWidthPortait: 410
         property int webviewWidthLandscape: 900
-        property int textFontSize: 110
-        property int spanFontSize: 104
+        property int textFontSize: 106
+        property int spanFontSize: 107
 
         property bool enableDesktopNotifications: true
         property bool enableTitleChangeNotifications: true
@@ -42,8 +42,19 @@ MainView {
 
         property bool enableQuickCopy: true
         property bool enableGpu: true
+        
+        property int updateRevision: 0;
     }
     
+ Component.onCompleted: {
+   if (config.updateRevision != 1)
+   {
+    config.textFontSize=106
+    config.spanFontSize=107
+    config.updateRevision=1;
+   }
+   
+ }
  DownloadHelper {
         id: downloadHelper
         blob_path: localStorage+"/IndexedDB/https_web.whatsapp.com_0.indexeddb.blob/"

--- a/whatsweb/app/SettingsPage.qml
+++ b/whatsweb/app/SettingsPage.qml
@@ -39,8 +39,8 @@ Page {
 
         property int webviewWidthPortait: 410
         property int webviewWidthLandscape: 900        
-        property int textFontSize: 110
-        property int spanFontSize: 104
+        property int textFontSize: 106
+        property int spanFontSize: 107
 
         property bool enableDesktopNotifications: true
         property bool enableTitleChangeNotifications: true
@@ -131,10 +131,10 @@ Page {
                 webviewWidthPortait.value = 410
                 config.webviewWidthLandscape = 900
                 webviewWidthLandscape.value = 900
-                config.textFontSize = 110
-                textFontSize.value = 110
-                config.spanFontSize = 104
-                spanFontSize.value = 104
+                config.textFontSize = 106
+                textFontSize.value = 106
+                config.spanFontSize = 107
+                spanFontSize.value = 107
 
                 config.enableDesktopNotifications = true
                 enableDesktopNotifications.checked = true

--- a/whatsweb/app/UCSComponents/NumberEditRow.qml
+++ b/whatsweb/app/UCSComponents/NumberEditRow.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick 2.9
 import Ubuntu.Components 1.3
 
 Row {

--- a/whatsweb/app/UCSComponents/SwitchRow.qml
+++ b/whatsweb/app/UCSComponents/SwitchRow.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick 2.9
 import Ubuntu.Components 1.3
 
 Row {

--- a/whatsweb/app/ubuntutheme.js
+++ b/whatsweb/app/ubuntutheme.js
@@ -72,10 +72,10 @@ const X = {
       chatListHeader: () => document.querySelector('.two').childNodes[4].querySelector('header').querySelector('header'),
     chatWindow: () => document.querySelector('.two').childNodes[5],
       chatHeader: () => document.querySelector('.two').childNodes[5].querySelector('header'),
+    contactInfo: () => document.querySelector('.two').childNodes[6],
   //-------------------------------------------------------------------------------------------
 
   upperWrapper: () => document.querySelector('.three'),
-    contactInfo: () => document.querySelector('.two').childNodes[6],
       
   leftMenu: () => document.querySelector('header'),
 
@@ -121,7 +121,8 @@ function main(){
         addCss(".message-out {  padding-right: 20px !important; }");
         addCss(".message-in {  padding-left: 20px !important; }");  
         addCss("span { font-size: "+window.appConfig.spanFontSize+"% !important; }");    
-        addCss(".selectable-text { font-size: "+window.appConfig.textFontSize+"% !important; }"); 
+        addCss(".copyable-text { font-size: "+window.appConfig.textFontSize+"% !important; }");         
+        addCss(".html-span { font-size: 96% !important; }");
     } catch (e) { console.log("Error while applying css: "+e) }
 
   
@@ -131,9 +132,14 @@ function main(){
   X.chatWindow().style.minWidth = "100%" 
   X.chatWindow().style.maxWidth = "100%"  
   X.chatWindow().style.width = "100%"   
-   X.mainWrapper().style.minWidth = 'auto';
-   X.mainWrapper().style.minHeight = 'auto';
-      X.unkownSection1().style.borderInlineStartWidth = "0" ;
+  X.mainWrapper().style.minWidth = 'auto';
+  X.mainWrapper().style.minHeight = 'auto';
+  X.unkownSection1().style.borderInlineStartWidth = "0" ;
+  
+  // Handle contactInfo Openned panel
+  if (X.contactInfo() !== undefined){
+        inchatcontactandgroupinfo();
+  }
       
    //--------------------------------------------------------------
    // SECTION2.1 Avoid opening the keyboard when entering a chat
@@ -204,13 +210,6 @@ function main(){
       X.dialog().style.minWidth="100%"
       X.dialog().firstChild.classList.add('customDialog')
     }
-  
-    // Handle contactInfo Openned panel
-    if (X.upperWrapper() !== undefined){
-      if (X.contactInfo() !== undefined){
-        inchatcontactandgroupinfo();
-      }
-    }
     
     backupBackButton()
     
@@ -245,17 +244,26 @@ window.addEventListener("click", function() {
         showchatWindow();
   
   setTimeout( () => {
-
   calculateSecondaryChatWindowOpen();
-  
+  },5);
+  setTimeout( () => {
   //(Re)-enable content Editable ( If it was disabled when "OnFocus" was called without click)
-  if ( lastClickEl.closest('.contenteditableDisabled')  )
+  if ( lastClickEl.closest('.contenteditableDisabled') !== null  )
   {
+    var editableEl=lastClickEl.closest('.contenteditableDisabled');
     lastClickEl.closest('.contenteditableDisabled').setAttribute('contenteditable', true);
     lastClickEl.closest('.contenteditableDisabled').classList.remove('contenteditableDisabled') 
+    editableEl.focus();
   }
-  needToShowChatWindow=0;
+  if ( lastClickEl.querySelector('.contenteditableDisabled') !== null  )
+  {
+    var editableEl=lastClickEl.querySelector('.contenteditableDisabled');
+    lastClickEl.querySelector('.contenteditableDisabled').setAttribute('contenteditable', true);
+    lastClickEl.querySelector('.contenteditableDisabled').classList.remove('contenteditableDisabled') 
+    editableEl.focus();
+  }
   },5);
+  
 }); 
 
 
@@ -344,6 +352,12 @@ function showchatWindow(){
     X.uploadPannel().style.width="100%";
     X.uploadPannel().style.minWidth="100%";   
     X.leftSettingPannel().style.display="none"; 
+    
+    // Handle contactInfo Openned panel
+    if (X.contactInfo() !== undefined){
+        inchatcontactandgroupinfo();
+    }
+  
     addBackButtonToChatViewWithTimeout();
 }
 
@@ -599,7 +613,6 @@ updatenotificacion = 0;
 allownotification = 0;
 var lastClickEl=null;
 var lastFocusEl=null;
-var needToShowChatWindow=0;
 var firstChatLoad=1;
 
   function addCss(cssString) {

--- a/whatsweb/manifest.json
+++ b/whatsweb/manifest.json
@@ -14,7 +14,7 @@
       "push-helper": "whatsweb-push-helper.json"
     }
   },
-  "version": "0.3.3",
+  "version": "0.3.4",
   "maintainer": "Adrian Campos <adriancampos@teachelp.com>",
   "framework": "ubuntu-sdk-20.04"
 }


### PR DESCRIPTION
Fix Search messages in chat window + adpat fontsize to changes upstream

This pull request is a minimal correction to fix searching messages in the Chat Window. It is a secondary feature but still very usefull for me. It also includes a small adaptation to Fontsize to match the changes that happened in Whatsapp web this Tuesday in that regard. As you can see the modifications in the code are quite short and limited so I hope it should not have any side-effect.

It should now offer 100% of the functionalities of Whatsapp web, and everything should display correctly.

The only drawback being that it is still a bit slughish, I hope it will improve a bit when upgrading to Qt6 or with other upcoming improvements in the OS, or even optimisations in the code of Whatsapp web itself coming from meta.

This time I hope I will not work on this project, until Qt6 release and that Meta will not release changes that break the thing until then (or if they do at least let it be for enabling calls in whatsapp web 😅) . (I might think one day, about ways for the app to be more resilient and self-adaptative to upstream changes, but not now)